### PR TITLE
implement notion block types as classes

### DIFF
--- a/src/Entities/Blocks/Block.php
+++ b/src/Entities/Blocks/Block.php
@@ -192,11 +192,11 @@ class Block extends Entity
                 $class = str_replace('_', '', ucwords($type, '_'));
                 return "FiveamCode\\LaravelNotionApi\\Entities\\Blocks\\" . $class;
             case 'heading_1':
-                return "FiveamCode\\LaravelNotionApi\\Entities\\Blocks\\HeadingOne";
+                return HeadingOne::class;
             case 'heading_2':
-                return "FiveamCode\\LaravelNotionApi\\Entities\\Blocks\\HeadingTwo";
+                return HeadingTwo::class;
             case 'heading_3':
-                return "FiveamCode\\LaravelNotionApi\\Entities\\Blocks\\HeadingThree";
+                return HeadingThree::class;
             default:
                 return Block::class;
         }

--- a/src/Entities/Blocks/Block.php
+++ b/src/Entities/Blocks/Block.php
@@ -29,6 +29,17 @@ class Block extends Entity
     protected array $rawContent;
 
     /**
+     * @var mixed
+     */
+    protected $content;
+
+
+    /**
+     * @var string
+     */
+    protected string $text = "[warning: unsupported in notion api]";
+
+    /**
      * @var DateTime
      */
     protected DateTime $createdTime;
@@ -54,7 +65,7 @@ class Block extends Entity
     /**
      *
      */
-    private function fillFromRaw(): void
+    protected function fillFromRaw(): void
     {
         $this->fillId();
         $this->fillType();
@@ -132,5 +143,62 @@ class Block extends Entity
     public function getLastEditedTime(): DateTime
     {
         return $this->lastEditedTime;
+    }
+
+    /**
+     * 
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    /**
+     * @return string
+     */
+    public function asText() : string
+    {
+        return $this->text;
+    }
+
+    /**
+     * @param $rawContent
+     * @return Block
+     * @throws HandlingException
+     */
+    public static function fromResponse($rawContent): Block
+    {
+        $blockClass = self::mapTypeToClass($rawContent['type']);
+        $block = new $blockClass($rawContent);
+        return $block;
+    }
+
+    /**
+     * Maps the type of a block to the corresponding package class by converting the type name.
+     *
+     * @param string $type
+     * @return string
+     */
+    private static function mapTypeToClass(string $type): string
+    {
+
+        switch ($type) {
+            case 'bulleted_list_item':
+            case 'numbered_list_item':
+            case 'child_page':
+            case 'paragraph':
+            case 'to_do':
+            case 'toggle':
+                $class = str_replace('_', '', ucwords($type, '_'));
+                return "FiveamCode\\LaravelNotionApi\\Entities\\Blocks\\" . $class;
+            case 'heading_1':
+                return "FiveamCode\\LaravelNotionApi\\Entities\\Blocks\\HeadingOne";
+            case 'heading_2':
+                return "FiveamCode\\LaravelNotionApi\\Entities\\Blocks\\HeadingTwo";
+            case 'heading_3':
+                return "FiveamCode\\LaravelNotionApi\\Entities\\Blocks\\HeadingThree";
+            default:
+                return Block::class;
+        }
     }
 }

--- a/src/Entities/Blocks/BulletedListItem.php
+++ b/src/Entities/Blocks/BulletedListItem.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FiveamCode\LaravelNotionApi\Entities\Blocks;
+
+use DateTime;
+use Illuminate\Support\Arr;
+use FiveamCode\LaravelNotionApi\Entities\Entity;
+use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
+
+/**
+ * Class BulletedListItem
+ * @package FiveamCode\LaravelNotionApi\Entities\Blocks
+ */
+class BulletedListItem extends TextBlock
+{
+}

--- a/src/Entities/Blocks/ChildPage.php
+++ b/src/Entities/Blocks/ChildPage.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace FiveamCode\LaravelNotionApi\Entities\Blocks;
+
+use DateTime;
+use Illuminate\Support\Arr;
+use FiveamCode\LaravelNotionApi\Entities\Entity;
+use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
+
+/**
+ * Class ChildPage
+ * @package FiveamCode\LaravelNotionApi\Entities\Blocks
+ */
+class ChildPage extends Block
+{
+    /**
+     * 
+     */
+    protected function fillFromRaw(): void
+    {
+        parent::fillFromRaw();
+        $this->fillContent();
+    }
+
+    /**
+     * 
+     */
+    protected function fillContent() : void
+    {
+        $this->content = $this->rawContent['title'];
+        $this->text = $this->getContent();
+    }
+
+    /**
+     * @return string
+     */
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+}

--- a/src/Entities/Blocks/HeadingOne.php
+++ b/src/Entities/Blocks/HeadingOne.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FiveamCode\LaravelNotionApi\Entities\Blocks;
+
+use DateTime;
+use Illuminate\Support\Arr;
+use FiveamCode\LaravelNotionApi\Entities\Entity;
+use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
+
+/**
+ * Class HeadingOne
+ * @package FiveamCode\LaravelNotionApi\Entities\Blocks
+ */
+class HeadingOne extends TextBlock
+{
+}

--- a/src/Entities/Blocks/HeadingThree.php
+++ b/src/Entities/Blocks/HeadingThree.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FiveamCode\LaravelNotionApi\Entities\Blocks;
+
+use DateTime;
+use Illuminate\Support\Arr;
+use FiveamCode\LaravelNotionApi\Entities\Entity;
+use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
+
+/**
+ * Class HeadingThree
+ * @package FiveamCode\LaravelNotionApi\Entities\Blocks
+ */
+class HeadingThree extends TextBlock
+{
+}

--- a/src/Entities/Blocks/HeadingTwo.php
+++ b/src/Entities/Blocks/HeadingTwo.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FiveamCode\LaravelNotionApi\Entities\Blocks;
+
+use DateTime;
+use Illuminate\Support\Arr;
+use FiveamCode\LaravelNotionApi\Entities\Entity;
+use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
+
+/**
+ * Class HeadingTwo
+ * @package FiveamCode\LaravelNotionApi\Entities\Blocks
+ */
+class HeadingTwo extends TextBlock
+{
+}

--- a/src/Entities/Blocks/NumberedListItem.php
+++ b/src/Entities/Blocks/NumberedListItem.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FiveamCode\LaravelNotionApi\Entities\Blocks;
+
+use DateTime;
+use Illuminate\Support\Arr;
+use FiveamCode\LaravelNotionApi\Entities\Entity;
+use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
+
+/**
+ * Class NumberedListItem
+ * @package FiveamCode\LaravelNotionApi\Entities\Blocks
+ */
+class NumberedListItem extends TextBlock
+{
+}

--- a/src/Entities/Blocks/Paragraph.php
+++ b/src/Entities/Blocks/Paragraph.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace FiveamCode\LaravelNotionApi\Entities\Blocks;
+
+use DateTime;
+use Illuminate\Support\Arr;
+use FiveamCode\LaravelNotionApi\Entities\Entity;
+use FiveamCode\LaravelNotionApi\Entities\PropertyItems\RichText;
+use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
+
+/**
+ * Class Paragraph
+ * @package FiveamCode\LaravelNotionApi\Entities\Blocks
+ */
+class Paragraph extends TextBlock
+{
+}

--- a/src/Entities/Blocks/TextBlock.php
+++ b/src/Entities/Blocks/TextBlock.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace FiveamCode\LaravelNotionApi\Entities\Blocks;
+
+use DateTime;
+use Illuminate\Support\Arr;
+use FiveamCode\LaravelNotionApi\Entities\Entity;
+use FiveamCode\LaravelNotionApi\Entities\PropertyItems\RichText;
+use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
+
+/**
+ * Class TextBlock
+ * @package FiveamCode\LaravelNotionApi\Entities\Blocks
+ */
+class TextBlock extends Block
+{
+    /**
+     * 
+     */
+    protected function fillFromRaw(): void
+    {
+        parent::fillFromRaw();
+        $this->fillContent();
+    }
+
+    /**
+     * 
+     */
+    protected function fillContent(): void
+    {
+        $this->content = new RichText($this->rawContent['text']);
+        $this->text = $this->getContent()->getPlainText();
+    }
+
+    /**
+     * @return RichText
+     */
+    public function getContent(): RichText
+    {
+        return $this->content;
+    }
+}

--- a/src/Entities/Blocks/ToDo.php
+++ b/src/Entities/Blocks/ToDo.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FiveamCode\LaravelNotionApi\Entities\Blocks;
+
+use DateTime;
+use Illuminate\Support\Arr;
+use FiveamCode\LaravelNotionApi\Entities\Entity;
+use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
+
+/**
+ * Class ToDo
+ * @package FiveamCode\LaravelNotionApi\Entities\Blocks
+ */
+class ToDo extends TextBlock
+{
+}

--- a/src/Entities/Blocks/Toggle.php
+++ b/src/Entities/Blocks/Toggle.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FiveamCode\LaravelNotionApi\Entities\Blocks;
+
+use DateTime;
+use Illuminate\Support\Arr;
+use FiveamCode\LaravelNotionApi\Entities\Entity;
+use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
+
+/**
+ * Class Toggle
+ * @package FiveamCode\LaravelNotionApi\Entities\Blocks
+ */
+class Toggle extends TextBlock
+{
+}

--- a/src/Entities/Collections/BlockCollection.php
+++ b/src/Entities/Collections/BlockCollection.php
@@ -14,12 +14,22 @@ class BlockCollection extends EntityCollection
 {
     private bool $showUnsupported = false;
 
+    /**
+     * will include unsupported blocks within your collection
+     * unsupported blocks are currently not supported by the Notion API 
+     * they will be ignored (not included) in your collection by default
+     * 
+     * @return BlockCollection
+     */
     public function withUnsupported(): BlockCollection
     {
         $this->showUnsupported = true;
         return $this;
     }
 
+    /**
+     * collects all blocks from the raw results (from notion)
+     */
     protected function collectChildren(): void
     {
         $this->collection = new Collection();
@@ -28,18 +38,29 @@ class BlockCollection extends EntityCollection
         }
     }
 
+    /**
+     * returns according blocks as collection
+     * 
+     * @return Collection
+     */
     public function asCollection(): Collection
     {
-        $collection =parent::asCollection();
+        $collection = parent::asCollection();
         if ($this->showUnsupported) {
             return $collection;
         } else {
-            return $collection->filter(function($block){
+            return $collection->filter(function ($block) {
                 return $block->getType() != 'unsupported';
             });
         }
     }
 
+    /**
+     * returns according blocks as collection and will only represent the textual content of the blocks
+     * (this is useful if you only want to work with the blocks content and not with the whole block object)
+     * 
+     * @return Collection
+     */
     public function asTextCollection(): Collection
     {
         $textCollection = new Collection();

--- a/src/Entities/Collections/BlockCollection.php
+++ b/src/Entities/Collections/BlockCollection.php
@@ -12,11 +12,40 @@ use FiveamCode\LaravelNotionApi\Entities\Blocks\Block;
  */
 class BlockCollection extends EntityCollection
 {
+    private bool $showUnsupported = false;
+
+    public function withUnsupported(): BlockCollection
+    {
+        $this->showUnsupported = true;
+        return $this;
+    }
+
     protected function collectChildren(): void
     {
         $this->collection = new Collection();
-        foreach ($this->rawResults as $blockChild) {
-            $this->collection->add(new Block($blockChild));
+        foreach ($this->rawResults as $blockChildContent) {
+            $this->collection->add(Block::fromResponse($blockChildContent));
         }
+    }
+
+    public function asCollection(): Collection
+    {
+        $collection =parent::asCollection();
+        if ($this->showUnsupported) {
+            return $collection;
+        } else {
+            return $collection->filter(function($block){
+                return $block->getType() != 'unsupported';
+            });
+        }
+    }
+
+    public function asTextCollection(): Collection
+    {
+        $textCollection = new Collection();
+        foreach ($this->asCollection() as $block) {
+            $textCollection->add($block->asText());
+        }
+        return $textCollection;
     }
 }

--- a/src/Entities/Collections/BlockCollection.php
+++ b/src/Entities/Collections/BlockCollection.php
@@ -50,7 +50,7 @@ class BlockCollection extends EntityCollection
             return $collection;
         } else {
             return $collection->filter(function ($block) {
-                return $block->getType() != 'unsupported';
+                return $block->getType() !== 'unsupported';
             });
         }
     }

--- a/src/Entities/Collections/EntityCollection.php
+++ b/src/Entities/Collections/EntityCollection.php
@@ -124,7 +124,7 @@ class EntityCollection
      */
     public function asJson(): string
     {
-        return $this->collection->map(function (Entity $item) {
+        return $this->asCollection()->map(function (Entity $item) {
             return $item->toArray();
         });
     }

--- a/tests/stubs/endpoints/blocks/response_specific_supported_blocks_200.json
+++ b/tests/stubs/endpoints/blocks/response_specific_supported_blocks_200.json
@@ -1,0 +1,240 @@
+{
+    "object": "list",
+    "results": [
+        {
+            "object": "block",
+            "id": "1d829dd4-563b-4387-b74f-20da92b827fb",
+            "created_time": "2021-07-17T16:51:00.000Z",
+            "last_edited_time": "2021-07-17T16:54:00.000Z",
+            "has_children": false,
+            "type": "paragraph",
+            "paragraph": {
+                "text": [
+                    {
+                        "type": "text",
+                        "text": {
+                            "content": "paragraph_block",
+                            "link": null
+                        },
+                        "annotations": {
+                            "bold": false,
+                            "italic": false,
+                            "strikethrough": false,
+                            "underline": false,
+                            "code": false,
+                            "color": "default"
+                        },
+                        "plain_text": "paragraph_block",
+                        "href": null
+                    }
+                ]
+            }
+        },
+        {
+            "object": "block",
+            "id": "616fc310-6c27-48f4-8c7e-1bf2bbb851a8",
+            "created_time": "2021-07-17T16:54:00.000Z",
+            "last_edited_time": "2021-07-17T16:54:00.000Z",
+            "has_children": false,
+            "type": "heading_1",
+            "heading_1": {
+                "text": [
+                    {
+                        "type": "text",
+                        "text": {
+                            "content": "heading_one_block",
+                            "link": null
+                        },
+                        "annotations": {
+                            "bold": false,
+                            "italic": false,
+                            "strikethrough": false,
+                            "underline": false,
+                            "code": false,
+                            "color": "default"
+                        },
+                        "plain_text": "heading_one_block",
+                        "href": null
+                    }
+                ]
+            }
+        },
+        {
+            "object": "block",
+            "id": "ad02c583-74bb-47a5-a00d-dc2b717051d5",
+            "created_time": "2021-07-17T16:54:00.000Z",
+            "last_edited_time": "2021-07-17T16:55:00.000Z",
+            "has_children": false,
+            "type": "heading_2",
+            "heading_2": {
+                "text": [
+                    {
+                        "type": "text",
+                        "text": {
+                            "content": "heading_two_block",
+                            "link": null
+                        },
+                        "annotations": {
+                            "bold": false,
+                            "italic": false,
+                            "strikethrough": false,
+                            "underline": false,
+                            "code": false,
+                            "color": "default"
+                        },
+                        "plain_text": "heading_two_block",
+                        "href": null
+                    }
+                ]
+            }
+        },
+        {
+            "object": "block",
+            "id": "797d5bfd-b5fc-432e-ba2a-e14a93174e2c",
+            "created_time": "2021-07-17T16:54:00.000Z",
+            "last_edited_time": "2021-07-17T16:55:00.000Z",
+            "has_children": false,
+            "type": "heading_3",
+            "heading_3": {
+                "text": [
+                    {
+                        "type": "text",
+                        "text": {
+                            "content": "heading_three_block",
+                            "link": null
+                        },
+                        "annotations": {
+                            "bold": false,
+                            "italic": false,
+                            "strikethrough": false,
+                            "underline": false,
+                            "code": false,
+                            "color": "default"
+                        },
+                        "plain_text": "heading_three_block",
+                        "href": null
+                    }
+                ]
+            }
+        },
+        {
+            "object": "block",
+            "id": "c4a0f595-7ad3-42c9-a2f0-dadf143b4c1e",
+            "created_time": "2021-07-17T16:54:00.000Z",
+            "last_edited_time": "2021-07-17T16:56:00.000Z",
+            "has_children": false,
+            "type": "bulleted_list_item",
+            "bulleted_list_item": {
+                "text": [
+                    {
+                        "type": "text",
+                        "text": {
+                            "content": "bulleted_list_item_block",
+                            "link": null
+                        },
+                        "annotations": {
+                            "bold": false,
+                            "italic": false,
+                            "strikethrough": false,
+                            "underline": false,
+                            "code": false,
+                            "color": "default"
+                        },
+                        "plain_text": "bulleted_list_item_block",
+                        "href": null
+                    }
+                ]
+            }
+        },
+        {
+            "object": "block",
+            "id": "52eb7c2a-13ee-4b78-936e-9019dbdbf113",
+            "created_time": "2021-07-17T16:55:00.000Z",
+            "last_edited_time": "2021-07-17T16:56:00.000Z",
+            "has_children": false,
+            "type": "numbered_list_item",
+            "numbered_list_item": {
+                "text": [
+                    {
+                        "type": "text",
+                        "text": {
+                            "content": "numbered_list_item_block",
+                            "link": null
+                        },
+                        "annotations": {
+                            "bold": false,
+                            "italic": false,
+                            "strikethrough": false,
+                            "underline": false,
+                            "code": false,
+                            "color": "default"
+                        },
+                        "plain_text": "numbered_list_item_block",
+                        "href": null
+                    }
+                ]
+            }
+        },
+        {
+            "object": "block",
+            "id": "2e58b063-5bb2-6c1c-8682-dbb6e26b153b",
+            "created_time": "2021-07-17T16:55:00.000Z",
+            "last_edited_time": "2021-07-17T17:03:00.000Z",
+            "has_children": false,
+            "type": "to_do",
+            "to_do": {
+                "text": [
+                    {
+                        "type": "text",
+                        "text": {
+                            "content": "to_do_block",
+                            "link": null
+                        },
+                        "annotations": {
+                            "bold": false,
+                            "italic": false,
+                            "strikethrough": false,
+                            "underline": false,
+                            "code": false,
+                            "color": "default"
+                        },
+                        "plain_text": "to_do_block",
+                        "href": null
+                    }
+                ],
+                "checked": false
+            }
+        },
+        {
+            "object": "block",
+            "id": "b96c259c-72b7-453f-9140-c6618af1fea3",
+            "created_time": "2021-07-17T16:56:00.000Z",
+            "last_edited_time": "2021-07-17T17:03:00.000Z",
+            "has_children": false,
+            "type": "toggle",
+            "toggle": {
+                "text": [
+                    {
+                        "type": "text",
+                        "text": {
+                            "content": "toggle_block",
+                            "link": null
+                        },
+                        "annotations": {
+                            "bold": false,
+                            "italic": false,
+                            "strikethrough": false,
+                            "underline": false,
+                            "code": false,
+                            "color": "default"
+                        },
+                        "plain_text": "toggle_block",
+                        "href": null
+                    }
+                ]
+            }
+        }
+    ],
+    "next_cursor": null,
+    "has_more": false
+}


### PR DESCRIPTION
- add easy content and text access for rich-text- (all supported blocks, exept page-blocks) and child-page-blocks
- add fromResponse- and mapTypeToClass-method to Block::class (similar to the implementations within Property::class)