### PR TITLE
add url to page

### DIFF
--- a/src/Entities/Page.php
+++ b/src/Entities/Page.php
@@ -106,7 +106,7 @@ class Page extends Entity
         $this->fillObjectType();
         $this->fillProperties();
         $this->fillTitle(); // This has to be called after fillProperties(), since title is provided by properties
-        $this->fillUrl();
+        $this->fillPageUrl();
         $this->fillCreatedTime();
         $this->fillLastEditedTime();
     }
@@ -160,7 +160,7 @@ class Page extends Entity
     /**
      * 
      */
-    private function fillUrl(): void
+    private function fillPageUrl(): void
     {
         if (Arr::exists($this->responseData, 'url')) {
             $this->url = $this->responseData['url'];

--- a/src/Entities/Page.php
+++ b/src/Entities/Page.php
@@ -34,6 +34,11 @@ class Page extends Entity
     /**
      * @var string
      */
+    protected string $url = '';
+
+    /**
+     * @var string
+     */
     protected string $objectType = '';
 
     /**
@@ -101,6 +106,7 @@ class Page extends Entity
         $this->fillObjectType();
         $this->fillProperties();
         $this->fillTitle(); // This has to be called after fillProperties(), since title is provided by properties
+        $this->fillUrl();
         $this->fillCreatedTime();
         $this->fillLastEditedTime();
     }
@@ -148,6 +154,16 @@ class Page extends Entity
                     $this->title = $rawTitleProperty[0]['plain_text'];
                 }
             }
+        }
+    }
+
+    /**
+     * 
+     */
+    private function fillUrl(): void
+    {
+        if (Arr::exists($this->responseData, 'url')) {
+            $this->url = $this->responseData['url'];
         }
     }
 
@@ -322,6 +338,14 @@ class Page extends Entity
     public function getTitle(): string
     {
         return $this->title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        return $this->url;
     }
 
     /**


### PR DESCRIPTION
- url is now retreived in the endpoint "->pages()->find($pageId)"
- url can now be read by the user in a straightforward way

[added to notion-api at 2021-07-02]
https://developers.notion.com/changelog/page-objects-now-return-url