### PR TITLE
Modifiable Contract

### DIFF
--- a/src/Entities/Contracts/Modifiable.php
+++ b/src/Entities/Contracts/Modifiable.php
@@ -6,5 +6,4 @@ use FiveamCode\LaravelNotionApi\Entities\Properties\Property;
 
 interface Modifiable
 {
-    public static function value($value): Property;
 }

--- a/src/Entities/Contracts/Modifiable.php
+++ b/src/Entities/Contracts/Modifiable.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace FiveamCode\LaravelNotionApi\Entities\Contracts;
+
+use FiveamCode\LaravelNotionApi\Entities\Properties\Property;
+
+interface Modifiable
+{
+    public static function value($value): Property;
+}

--- a/src/Entities/Properties/Checkbox.php
+++ b/src/Entities/Properties/Checkbox.php
@@ -2,13 +2,14 @@
 
 namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 
+use FiveamCode\LaravelNotionApi\Entities\Contracts\Modifiable;
 use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
 
 /**
  * Class Checkbox
  * @package FiveamCode\LaravelNotionApi\Entities\Properties
  */
-class Checkbox extends Property
+class Checkbox extends Property implements Modifiable
 {
 
     /**

--- a/src/Entities/Properties/Date.php
+++ b/src/Entities/Properties/Date.php
@@ -3,14 +3,15 @@
 namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 
 use DateTime;
-use FiveamCode\LaravelNotionApi\Entities\PropertyItems\RichDate;
 use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
+use FiveamCode\LaravelNotionApi\Entities\Contracts\Modifiable;
+use FiveamCode\LaravelNotionApi\Entities\PropertyItems\RichDate;
 
 /**
  * Class Date
  * @package FiveamCode\LaravelNotionApi\Entities\Properties
  */
-class Date extends Property
+class Date extends Property implements Modifiable
 {
 
     /**

--- a/src/Entities/Properties/Email.php
+++ b/src/Entities/Properties/Email.php
@@ -2,11 +2,13 @@
 
 namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 
+use FiveamCode\LaravelNotionApi\Entities\Contracts\Modifiable;
+
 /**
  * Class Email
  * @package FiveamCode\LaravelNotionApi\Entities\Properties
  */
-class Email extends Property
+class Email extends Property implements Modifiable
 {
     /**
      * @param $email

--- a/src/Entities/Properties/MultiSelect.php
+++ b/src/Entities/Properties/MultiSelect.php
@@ -2,6 +2,7 @@
 
 namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 
+use FiveamCode\LaravelNotionApi\Entities\Contracts\Modifiable;
 use Illuminate\Support\Collection;
 use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
 use FiveamCode\LaravelNotionApi\Entities\PropertyItems\SelectItem;
@@ -10,7 +11,7 @@ use FiveamCode\LaravelNotionApi\Entities\PropertyItems\SelectItem;
  * Class MultiSelect
  * @package FiveamCode\LaravelNotionApi\Entities\Properties
  */
-class MultiSelect extends Property
+class MultiSelect extends Property implements Modifiable
 {
     /**
      * @param $names

--- a/src/Entities/Properties/Number.php
+++ b/src/Entities/Properties/Number.php
@@ -2,11 +2,13 @@
 
 namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 
+use FiveamCode\LaravelNotionApi\Entities\Contracts\Modifiable;
+
 /**
  * Class Number
  * @package FiveamCode\LaravelNotionApi\Entities\Properties
  */
-class Number extends Property
+class Number extends Property implements Modifiable
 {
     /**
      * @var float|int

--- a/src/Entities/Properties/People.php
+++ b/src/Entities/Properties/People.php
@@ -2,6 +2,7 @@
 
 namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 
+use FiveamCode\LaravelNotionApi\Entities\Contracts\Modifiable;
 use FiveamCode\LaravelNotionApi\Entities\User;
 use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
 use Illuminate\Support\Collection;
@@ -10,7 +11,7 @@ use Illuminate\Support\Collection;
  * Class People
  * @package FiveamCode\LaravelNotionApi\Entities\Properties
  */
-class People extends Property
+class People extends Property implements Modifiable
 {
     /**
      * @param $userIds

--- a/src/Entities/Properties/PhoneNumber.php
+++ b/src/Entities/Properties/PhoneNumber.php
@@ -2,11 +2,13 @@
 
 namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 
+use FiveamCode\LaravelNotionApi\Entities\Contracts\Modifiable;
+
 /**
  * Class PhoneNumber
  * @package FiveamCode\LaravelNotionApi\Entities\Properties
  */
-class PhoneNumber extends Property
+class PhoneNumber extends Property implements Modifiable
 {
     /**
      * @param $phoneNumber

--- a/src/Entities/Properties/Relation.php
+++ b/src/Entities/Properties/Relation.php
@@ -2,13 +2,14 @@
 
 namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 
+use FiveamCode\LaravelNotionApi\Entities\Contracts\Modifiable;
 use Illuminate\Support\Collection;
 
 /**
  * Class Relation
  * @package FiveamCode\LaravelNotionApi\Entities\Properties
  */
-class Relation extends Property
+class Relation extends Property implements Modifiable
 {
     /**
      * @param $relationIds

--- a/src/Entities/Properties/Select.php
+++ b/src/Entities/Properties/Select.php
@@ -2,6 +2,7 @@
 
 namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 
+use FiveamCode\LaravelNotionApi\Entities\Contracts\Modifiable;
 use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
 use FiveamCode\LaravelNotionApi\Entities\PropertyItems\SelectItem;
 
@@ -9,7 +10,7 @@ use FiveamCode\LaravelNotionApi\Entities\PropertyItems\SelectItem;
  * Class Select
  * @package FiveamCode\LaravelNotionApi\Entities\Properties
  */
-class Select extends Property
+class Select extends Property implements Modifiable
 {
 
     /**

--- a/src/Entities/Properties/Text.php
+++ b/src/Entities/Properties/Text.php
@@ -2,6 +2,7 @@
 
 namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 
+use FiveamCode\LaravelNotionApi\Entities\Contracts\Modifiable;
 use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
 use FiveamCode\LaravelNotionApi\Entities\PropertyItems\RichText;
 
@@ -9,7 +10,7 @@ use FiveamCode\LaravelNotionApi\Entities\PropertyItems\RichText;
  * Class Text
  * @package FiveamCode\LaravelNotionApi\Entities\Properties
  */
-class Text extends Property
+class Text extends Property implements Modifiable
 {
     /**
      * @var string

--- a/src/Entities/Properties/Title.php
+++ b/src/Entities/Properties/Title.php
@@ -2,6 +2,7 @@
 
 namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 
+use FiveamCode\LaravelNotionApi\Entities\Contracts\Modifiable;
 use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
 use FiveamCode\LaravelNotionApi\Entities\PropertyItems\RichText;
 
@@ -9,7 +10,7 @@ use FiveamCode\LaravelNotionApi\Entities\PropertyItems\RichText;
  * Class Title
  * @package FiveamCode\LaravelNotionApi\Entities\Properties
  */
-class Title extends Property
+class Title extends Property implements Modifiable
 {
     /**
      * @var string

--- a/src/Entities/Properties/Url.php
+++ b/src/Entities/Properties/Url.php
@@ -2,11 +2,13 @@
 
 namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 
+use FiveamCode\LaravelNotionApi\Entities\Contracts\Modifiable;
+
 /**
  * Class Url
  * @package FiveamCode\LaravelNotionApi\Entities\Properties
  */
-class Url extends Property
+class Url extends Property implements Modifiable
 {
     /**
      * @param $url


### PR DESCRIPTION
I thought it would be useful to add the `value()` method to the `Modifiable` contract, because all modifiable properties share this method. However, while the return type of the `value()` method is always an inheritant of `Property`, the input parameter to this method differ a lot. Just compare `Text` with `Multiselect` for example, so the interface method is not suitable for inheritance (this is why all the tests fail of course). 
So, one possibility is to implement the Modifiable Contract as an empty interface without any declarations just for better code readability / overview purpose. The other possibility is to toss it completely. ^^
@johguentner What do you think?