### PR TITLE
improve database retrieval and add icon/cover

### DIFF
--- a/src/Endpoints/Databases.php
+++ b/src/Endpoints/Databases.php
@@ -26,6 +26,7 @@ class Databases extends Endpoint implements EndpointInterface
      * @return DatabaseCollection
      * @throws HandlingException
      * @throws NotionException
+     * @deprecated
      */
     public function all(): DatabaseCollection
     {

--- a/src/Endpoints/Databases.php
+++ b/src/Endpoints/Databases.php
@@ -37,7 +37,7 @@ class Databases extends Endpoint implements EndpointInterface
     /**
      * Retrieve a database
      * url: https://api.notion.com/{version}/databases/{database_id}
-     * notion-api-docs: https://developers.notion.com/reference/get-database
+     * notion-api-docs: https://developers.notion.com/reference/retrieve-a-database 
      *
      * @param string $databaseId
      * @return Database

--- a/src/Entities/Database.php
+++ b/src/Entities/Database.php
@@ -3,8 +3,10 @@
 namespace FiveamCode\LaravelNotionApi\Entities;
 
 use DateTime;
+use FiveamCode\LaravelNotionApi\Entities\Properties\Property;
 use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 
 
 /**
@@ -13,15 +15,81 @@ use Illuminate\Support\Arr;
  */
 class Database extends Entity
 {
+    /**
+     * @var string
+     */
     protected string $title = '';
+
+    /**
+     * @var string
+     */
+    private string $icon = '';
+
+    /**
+     * @var string
+     */
+    private string $iconType = '';
+
+    /**
+     * @var string
+     */
+    private string $cover = '';
+
+    /**
+     * @var string
+     */
+    private string $coverType = '';
+
+    /**
+     * @var string
+     */
+    private string $url;
+
+    /**
+     * @var string
+     */
     protected string $objectType = '';
+
+    /**
+     * @var array
+     */
     protected array $rawTitle = [];
+
+    /**
+     * @var array
+     */
     protected array $rawProperties = [];
+
+    /**
+     * @var array
+     */
     protected array $propertyKeys = [];
+
+    /**
+     * @var array
+     */
+    protected array $propertyMap = [];
+
+    /**
+     * @var Collection
+     */
+    protected Collection $properties;
+
+    /**
+     * @var DateTime
+     */
     protected DateTime $createdTime;
+
+    /**
+     * @var DateTime
+     */
     protected DateTime $lastEditedTime;
 
 
+
+    /**
+     * 
+     */
     protected function setResponseData(array $responseData): void
     {
         parent::setResponseData($responseData);
@@ -30,17 +98,25 @@ class Database extends Entity
         $this->fillFromRaw();
     }
 
-
+    /**
+     *
+     */
     private function fillFromRaw()
     {
         $this->fillId();
+        $this->fillIcon();
+        $this->fillCover();
         $this->fillTitle();
         $this->fillObjectType();
         $this->fillProperties();
+        $this->fillDatabaseUrl();
         $this->fillCreatedTime();
         $this->fillLastEditedTime();
     }
 
+    /**
+     *
+     */
     private function fillTitle(): void
     {
         if (Arr::exists($this->responseData, 'title') && is_array($this->responseData['title'])) {
@@ -49,6 +125,54 @@ class Database extends Entity
         }
     }
 
+    /**
+     *
+     */
+    private function fillDatabaseUrl(): void
+    {
+        if (Arr::exists($this->responseData, 'url')) {
+            $this->url = $this->responseData['url'];
+        }
+    }
+
+      /**
+     *
+     */
+    private function fillIcon(): void
+    {
+        if (Arr::exists($this->responseData, 'icon') && $this->responseData['icon'] != null) {
+            $this->iconType = $this->responseData['icon']['type'];
+            if(Arr::exists($this->responseData['icon'], 'emoji')){
+                $this->icon = $this->responseData['icon']['emoji'];
+            }
+            else if(Arr::exists($this->responseData['icon'], 'file')){
+                $this->icon = $this->responseData['icon']['file']['url'];
+            }
+            else if(Arr::exists($this->responseData['icon'], 'external')){
+                $this->icon = $this->responseData['icon']['external']['url'];
+            }
+        }
+    }
+
+     /**
+     *
+     */
+    private function fillCover(): void
+    {
+        if (Arr::exists($this->responseData, 'cover') && $this->responseData['cover'] != null) {
+            $this->coverType = $this->responseData['cover']['type'];
+            if(Arr::exists($this->responseData['cover'], 'file')){
+                $this->cover = $this->responseData['cover']['file']['url'];
+            }
+            else if(Arr::exists($this->responseData['cover'], 'external')){
+                $this->cover = $this->responseData['cover']['external']['url'];
+            }
+        }
+    }
+
+    /**
+     *
+     */
     private function fillObjectType(): void
     {
         if (Arr::exists($this->responseData, 'object')) {
@@ -56,29 +180,95 @@ class Database extends Entity
         }
     }
 
+    /**
+     *
+     */
     private function fillProperties(): void
     {
         if (Arr::exists($this->responseData, 'properties')) {
             $this->rawProperties = $this->responseData['properties'];
             $this->propertyKeys = array_keys($this->rawProperties);
+            $this->properties = new Collection();
+
+            foreach ($this->rawProperties as $propertyKey => $propertyContent) {
+                $propertyObj = Property::fromResponse($propertyKey, $propertyContent);
+                $this->properties->add($propertyObj);
+                $this->propertyMap[$propertyKey] = $propertyObj;
+            }
         }
     }
 
+    /**
+     * @param string $propertyKey
+     * @return Property|null
+     */
+    public function getProperty(string $propertyKey): ?Property
+    {
+        if (!isset($this->propertyMap[$propertyKey])) {
+            return null;
+        }
+        return $this->propertyMap[$propertyKey];
+    }
+
+    /**
+     * @return string
+     */
     public function getObjectType(): string
     {
         return $this->objectType;
     }
 
-
+    /**
+     * @return string
+     */
     public function getTitle(): string
     {
         return $this->title;
     }
 
-    public function getProperties()
+    /**
+     * @return string
+     */
+    public function getUrl(): string
     {
-        //TODO: return collection of property-entities (id, type, title)
-        throw new HandlingException('Not implemented');
+        return $this->url;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIcon(): string
+    {
+        return $this->icon;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIconType(): string
+    {
+        return $this->iconType;
+    }
+
+        /**
+     * @return string
+     */
+    public function getCover(): string
+    {
+        return $this->cover;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCoverType(): string
+    {
+        return $this->coverType;
+    }
+
+    public function getProperties(): Collection
+    {
+        return $this->properties;
     }
 
     public function getRawTitle(): array

--- a/src/Entities/Database.php
+++ b/src/Entities/Database.php
@@ -266,31 +266,49 @@ class Database extends Entity
         return $this->coverType;
     }
 
+    /**
+     * @return Collection
+     */
     public function getProperties(): Collection
     {
         return $this->properties;
     }
 
+    /**
+     * @return array
+     */
     public function getRawTitle(): array
     {
         return $this->rawTitle;
     }
 
+    /**
+     * @return array
+     */
     public function getRawProperties(): array
     {
         return $this->rawProperties;
     }
 
+    /**
+     * @return array
+     */
     public function getPropertyKeys(): array
     {
         return $this->propertyKeys;
     }
 
+    /**
+     * @return DateTime
+     */
     public function getCreatedTime(): DateTime
     {
         return $this->createdTime;
     }
 
+    /**
+     * @return array
+     */
     public function getLastEditedTime(): DateTime
     {
         return $this->lastEditedTime;

--- a/src/Entities/Page.php
+++ b/src/Entities/Page.php
@@ -36,6 +36,27 @@ class Page extends Entity
      */
     protected string $url = '';
 
+
+    /**
+     * @var string
+     */
+    private string $icon = '';
+
+    /**
+     * @var string
+     */
+    private string $iconType = '';
+
+    /**
+     * @var string
+     */
+    private string $cover = '';
+
+    /**
+     * @var string
+     */
+    private string $coverType = '';
+
     /**
      * @var string
      */
@@ -107,6 +128,8 @@ class Page extends Entity
         $this->fillProperties();
         $this->fillTitle(); // This has to be called after fillProperties(), since title is provided by properties
         $this->fillPageUrl();
+        $this->fillIcon();
+        $this->fillCover();
         $this->fillCreatedTime();
         $this->fillLastEditedTime();
     }
@@ -153,6 +176,41 @@ class Page extends Entity
                 if (Arr::exists($rawTitleProperty[0], 'plain_text')) {
                     $this->title = $rawTitleProperty[0]['plain_text'];
                 }
+            }
+        }
+    }
+
+     /**
+     *
+     */
+    private function fillIcon(): void
+    {
+        if (Arr::exists($this->responseData, 'icon') && $this->responseData['icon'] != null) {
+            $this->iconType = $this->responseData['icon']['type'];
+            if(Arr::exists($this->responseData['icon'], 'emoji')){
+                $this->icon = $this->responseData['icon']['emoji'];
+            }
+            else if(Arr::exists($this->responseData['icon'], 'file')){
+                $this->icon = $this->responseData['icon']['file']['url'];
+            }
+            else if(Arr::exists($this->responseData['icon'], 'external')){
+                $this->icon = $this->responseData['icon']['external']['url'];
+            }
+        }
+    }
+
+     /**
+     *
+     */
+    private function fillCover(): void
+    {
+        if (Arr::exists($this->responseData, 'cover') && $this->responseData['cover'] != null) {
+            $this->coverType = $this->responseData['cover']['type'];
+            if(Arr::exists($this->responseData['cover'], 'file')){
+                $this->cover = $this->responseData['cover']['file']['url'];
+            }
+            else if(Arr::exists($this->responseData['cover'], 'external')){
+                $this->cover = $this->responseData['cover']['external']['url'];
             }
         }
     }
@@ -338,6 +396,38 @@ class Page extends Entity
     public function getTitle(): string
     {
         return $this->title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIcon(): string
+    {
+        return $this->icon;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIconType(): string
+    {
+        return $this->iconType;
+    }
+
+        /**
+     * @return string
+     */
+    public function getCover(): string
+    {
+        return $this->cover;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCoverType(): string
+    {
+        return $this->coverType;
     }
 
     /**

--- a/src/Entities/Properties/CreatedTime.php
+++ b/src/Entities/Properties/CreatedTime.php
@@ -18,12 +18,11 @@ class CreatedTime extends Property
     protected function fillFromRaw(): void
     {
         parent::fillFromRaw();
-        if ($this->rawContent == null) {
-            throw HandlingException::instance('The property-type is created_time, however the raw data-structure is null. Please check the raw response-data.');
-        }
 
         try {
-            $this->content = new DateTime($this->rawContent);
+            if ($this->rawContent != null) {
+                $this->content = new DateTime($this->rawContent);
+            }
         } catch (Exception $e) {
             throw HandlingException::instance('The content of created_time is not a valid ISO 8601 date time string.');
         }

--- a/src/Entities/Properties/Formula.php
+++ b/src/Entities/Properties/Formula.php
@@ -20,14 +20,16 @@ class Formula extends Property
     {
         parent::fillFromRaw();
 
-        $this->formulaType = $this->rawContent['type'];
+        if (array_key_exists('type', $this->rawContent)) {
+            $this->formulaType = $this->rawContent['type'];
 
-        if ($this->formulaType == 'string' || $this->formulaType == 'number' || $this->formulaType == 'boolean') {
-            $this->content = $this->rawContent[$this->formulaType];
-        } else if ($this->formulaType == 'date') {
-            $this->content = new RichDate();
-            if (isset($this->rawContent[$this->formulaType]['start'])) $this->content->setStart(new DateTime($this->rawContent[$this->formulaType]['start']));
-            if (isset($this->rawContent[$this->formulaType]['end'])) $this->content->setEnd(new DateTime($this->rawContent[$this->formulaType]['end']));
+            if ($this->formulaType == 'string' || $this->formulaType == 'number' || $this->formulaType == 'boolean') {
+                $this->content = $this->rawContent[$this->formulaType];
+            } else if ($this->formulaType == 'date') {
+                $this->content = new RichDate();
+                if (isset($this->rawContent[$this->formulaType]['start'])) $this->content->setStart(new DateTime($this->rawContent[$this->formulaType]['start']));
+                if (isset($this->rawContent[$this->formulaType]['end'])) $this->content->setEnd(new DateTime($this->rawContent[$this->formulaType]['end']));
+            }
         }
     }
 

--- a/src/Entities/Properties/Formula.php
+++ b/src/Entities/Properties/Formula.php
@@ -4,6 +4,7 @@ namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 
 use DateTime;
 use FiveamCode\LaravelNotionApi\Entities\PropertyItems\RichDate;
+use Illuminate\Support\Arr;
 
 /**
  * Class Formula
@@ -20,12 +21,12 @@ class Formula extends Property
     {
         parent::fillFromRaw();
 
-        if (array_key_exists('type', $this->rawContent)) {
+        if (Arr::exists($this->rawContent, 'type')) {
             $this->formulaType = $this->rawContent['type'];
 
-            if ($this->formulaType == 'string' || $this->formulaType == 'number' || $this->formulaType == 'boolean') {
+            if ($this->formulaType === 'string' || $this->formulaType === 'number' || $this->formulaType === 'boolean') {
                 $this->content = $this->rawContent[$this->formulaType];
-            } else if ($this->formulaType == 'date') {
+            } else if ($this->formulaType === 'date') {
                 $this->content = new RichDate();
                 if (isset($this->rawContent[$this->formulaType]['start'])) $this->content->setStart(new DateTime($this->rawContent[$this->formulaType]['start']));
                 if (isset($this->rawContent[$this->formulaType]['end'])) $this->content->setEnd(new DateTime($this->rawContent[$this->formulaType]['end']));

--- a/src/Entities/Properties/LastEditedTime.php
+++ b/src/Entities/Properties/LastEditedTime.php
@@ -18,12 +18,11 @@ class LastEditedTime extends Property
     protected function fillFromRaw(): void
     {
         parent::fillFromRaw();
-        if ($this->rawContent == null) {
-            throw HandlingException::instance('The property-type is last_edited_time, however the raw data-structure is null. Please check the raw response-data.');
-        }
 
         try {
-            $this->content = new DateTime($this->rawContent);
+            if ($this->rawContent != null) {
+                $this->content = new DateTime($this->rawContent);
+            }
         } catch (Exception $e) {
             throw HandlingException::instance('The content of last_edited_time is not a valid ISO 8601 date time string.');
         }

--- a/src/Entities/Properties/LastEditedTime.php
+++ b/src/Entities/Properties/LastEditedTime.php
@@ -20,7 +20,7 @@ class LastEditedTime extends Property
         parent::fillFromRaw();
 
         try {
-            if ($this->rawContent != null) {
+            if ($this->rawContent !== null) {
                 $this->content = new DateTime($this->rawContent);
             }
         } catch (Exception $e) {

--- a/src/Entities/Properties/MultiSelect.php
+++ b/src/Entities/Properties/MultiSelect.php
@@ -14,6 +14,11 @@ use Illuminate\Support\Collection;
 class MultiSelect extends Property implements Modifiable
 {
     /**
+     * @var Collection 
+     */
+    private Collection $options;
+
+    /**
      * @param $names
      * @return MultiSelect
      */
@@ -51,8 +56,16 @@ class MultiSelect extends Property implements Modifiable
 
         $itemCollection = new Collection();
 
-        foreach ($this->rawContent as $item) {
-            $itemCollection->add(new SelectItem($item));
+        if(array_key_exists('options', $this->rawContent)){
+            $this->options = new Collection();
+            foreach ($this->rawContent['options'] as $key => $item) {
+                $this->options->add(new SelectItem($item));
+            }
+        }
+        else{
+            foreach ($this->rawContent as $key => $item) {
+                $itemCollection->add(new SelectItem($item));
+            }
         }
 
         $this->content = $itemCollection;
@@ -72,6 +85,14 @@ class MultiSelect extends Property implements Modifiable
     public function getItems(): Collection
     {
         return $this->content;
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getOptions(): Collection
+    {
+        return $this->options;
     }
 
     /**

--- a/src/Entities/Properties/MultiSelect.php
+++ b/src/Entities/Properties/MultiSelect.php
@@ -5,6 +5,7 @@ namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 use FiveamCode\LaravelNotionApi\Entities\Contracts\Modifiable;
 use FiveamCode\LaravelNotionApi\Entities\PropertyItems\SelectItem;
 use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 /**
@@ -56,7 +57,7 @@ class MultiSelect extends Property implements Modifiable
 
         $itemCollection = new Collection();
 
-        if(array_key_exists('options', $this->rawContent)){
+        if(Arr::exists($this->rawContent, 'options')){
             $this->options = new Collection();
             foreach ($this->rawContent['options'] as $key => $item) {
                 $this->options->add(new SelectItem($item));

--- a/src/Entities/Properties/Rollup.php
+++ b/src/Entities/Properties/Rollup.php
@@ -5,6 +5,7 @@ namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 use DateTime;
 use FiveamCode\LaravelNotionApi\Entities\PropertyItems\RichDate;
 use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 /**
@@ -22,7 +23,7 @@ class Rollup extends Property
     {
         parent::fillFromRaw();
 
-        if(array_key_exists('type', $this->rawContent))
+        if(Arr::exists($this->rawContent, 'type'))
         {
             $this->rollupType = $this->rawContent['type'];
 

--- a/src/Entities/Properties/Rollup.php
+++ b/src/Entities/Properties/Rollup.php
@@ -22,21 +22,24 @@ class Rollup extends Property
     {
         parent::fillFromRaw();
 
-        $this->rollupType = $this->rawContent['type'];
+        if(array_key_exists('type', $this->rawContent))
+        {
+            $this->rollupType = $this->rawContent['type'];
 
-        switch ($this->rollupType) {
-            case 'number':
-                $this->setRollupContentNumber();
-                break;
-            case 'array':
-                $this->setRollupContentArray();
-                break;
-            case 'date':
-                $this->setRollupContentDate();
-                break;
-            default:
-                throw new HandlingException("Unexpected rollupType {$this->rollupType}");
+            switch ($this->rollupType) {
+                case 'number':
+                    $this->setRollupContentNumber();
+                    break;
+                case 'array':
+                    $this->setRollupContentArray();
+                    break;
+                case 'date':
+                    $this->setRollupContentDate();
+                    break;
+                default:
+                    throw new HandlingException("Unexpected rollupType {$this->rollupType}");
         }
+    }
     }
 
     /**

--- a/src/Entities/Properties/Select.php
+++ b/src/Entities/Properties/Select.php
@@ -5,6 +5,7 @@ namespace FiveamCode\LaravelNotionApi\Entities\Properties;
 use FiveamCode\LaravelNotionApi\Entities\Contracts\Modifiable;
 use FiveamCode\LaravelNotionApi\Entities\PropertyItems\SelectItem;
 use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
+use Illuminate\Database\Eloquent\Collection;
 
 /**
  * Class Select
@@ -12,6 +13,10 @@ use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
  */
 class Select extends Property implements Modifiable
 {
+    /**
+     * @var Collection 
+     */
+    private Collection $options;
 
     /**
      * @param $name
@@ -43,7 +48,16 @@ class Select extends Property implements Modifiable
         if (!is_array($this->rawContent))
             throw HandlingException::instance('The property-type is select, however the raw data-structure does not reprecent this type. Please check the raw response-data.');
 
-        $this->content = new SelectItem($this->rawContent);
+        if (array_key_exists('options', $this->rawContent)) {
+            $this->options = new Collection();
+            foreach ($this->rawContent['options'] as $key => $item) {
+                $this->options->add(new SelectItem($item));
+            }
+        } else {
+            foreach ($this->rawContent as $key => $item) {
+                $this->content = new SelectItem($this->rawContent);
+            }
+        }
     }
 
     /**
@@ -60,6 +74,14 @@ class Select extends Property implements Modifiable
     public function getItem(): SelectItem
     {
         return $this->content;
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getOptions(): Collection
+    {
+        return $this->options;
     }
 
     /**

--- a/tests/stubs/endpoints/databases/response_all_200.json
+++ b/tests/stubs/endpoints/databases/response_all_200.json
@@ -7,10 +7,12 @@
       "title": "Grocery list",
       "properties": {
         "Name": {
+          "id": "testid",
           "type": "title",
           "title": {}
         },
         "Description": {
+          "id": "testid",
           "type": "text",
           "text": {}
         }
@@ -22,10 +24,12 @@
       "title": "Pantry",
       "properties": {
         "Name": {
+          "id": "testid",
           "type": "title",
           "title": {}
         },
         "Description": {
+          "id": "testid",
           "type": "rich_text",
           "rich_text": {}
         }

--- a/tests/stubs/endpoints/databases/response_specific_200.json
+++ b/tests/stubs/endpoints/databases/response_specific_200.json
@@ -81,6 +81,7 @@
       "date": {}
     },
     "Meals": {
+      "id": "Z\\Eh",
       "type": "relation",
       "relation": {
         "database": "668d797c-76fa-4934-9b05-ad288df2d136",
@@ -99,9 +100,10 @@
       }
     },
     "Store availability": {
+      "id": "Z\\Eh",
       "type": "multi_select",
       "multi_select": {
-        "options": [
+        "options": 
           [
             {
               "id": "d209b920-212c-4040-9d4a-bdf349dd8b2a",
@@ -124,7 +126,6 @@
               "color": "yellow"
             }
           ]
-        ]
       }
     },
     "+1": {


### PR DESCRIPTION
improve database retrieval and add icon/cover:
- replace notion-api-docs link with updated page (Databases)
- add icon, iconType, cover, coverType to Database and Page with according extraction of different cover- and icon-types
- add database-notion-url retrieval to database
- add raw-information-retrieval to database-retrieval (add as empty properties with according information to property-key and options)
- add retrieval of available options to MultiSelect and Select during database retrieval
- don't retrieve rollup and formula if type-value is not given
- don't retrieve created_time and last_edited_time if retrieved content is null
- fix missing id's and wrong options-field (array in array) within response-json-files
- mark databases->all() as deprecated