### PR TITLE
add block-update functionality + flexible content

### DIFF
--- a/src/Endpoints/Block.php
+++ b/src/Endpoints/Block.php
@@ -97,8 +97,34 @@ class Block extends Endpoint
             "children" => $children
         ];
 
+
         $response = $this->patch(
             $this->url(Endpoint::BLOCKS . '/' . $this->blockId . '/children' . ""),
+            $body
+        );
+
+        return new BlockEntity($response->json());
+    }
+
+
+    /**
+     * Update one specific Block 
+     * url: https://api.notion.com/{version}/blocks/{block_id} [patch]
+     * notion-api-docs: https://developers.notion.com/reference/update-a-block
+     *
+     * @return FiveamCode\LaravelNotionApi\Entities\Blocks\Block
+     * @throws HandlingException
+     */
+    public function update(BlockEntity $block): BlockEntity
+    {
+        $body = [
+            "object" => "block",
+            "type" => $block->getType(),
+            $block->getType() => $block->getRawContent()
+        ];
+
+        $response = $this->patch(
+            $this->url(Endpoint::BLOCKS . '/' . $this->blockId . ""),
             $body
         );
 

--- a/src/Entities/Blocks/Block.php
+++ b/src/Entities/Blocks/Block.php
@@ -114,6 +114,14 @@ class Block extends Entity
     }
 
     /**
+     * @return string
+     */
+    public function setType(string $type): void
+    {
+        $this->type = $type;
+    }
+
+    /**
      * @return array
      */
     public function getRawContent(): array
@@ -164,6 +172,10 @@ class Block extends Entity
     public function setContent($content)
     {
         $this->content = $content;
+    }
+
+    public function setRawContent($rawContent){
+        $this->rawContent = $rawContent;
     }
 
     /**

--- a/src/Entities/Blocks/TextBlock.php
+++ b/src/Entities/Blocks/TextBlock.php
@@ -36,6 +36,21 @@ class TextBlock extends Block implements Modifiable
         return $textBlock;
     }
 
+    public function setContent($content): TextBlock
+    {
+        $this->getContent()->setPlainText($content);
+
+        $text[] = [
+            "type" => "text",
+            "text" => [
+                "content" => $content
+            ]
+        ];
+
+        $this->rawContent['text'] = $text;
+        return $this;
+    }
+
     /**
      *
      */


### PR DESCRIPTION
- allow users to set rawContent and type for flexible block creation, until all blocks are supported by laravel-notion-api
- implement setContent for text based blocks