### PR TITLE
65 rollup with empty select fix

### DIFF
--- a/src/Entities/Properties/Rollup.php
+++ b/src/Entities/Properties/Rollup.php
@@ -101,7 +101,7 @@ class Rollup extends Property
     {
         return Arr::exists($rollupPropertyItem, 'type')
             && Arr::exists($rollupPropertyItem, $rollupPropertyItem['type'])
-            && !is_null($rollupPropertyItem[$rollupPropertyItem['type']]);
+            && ! is_null($rollupPropertyItem[$rollupPropertyItem['type']]);
     }
 
     private function setRollupContentDate()

--- a/src/Entities/Properties/Rollup.php
+++ b/src/Entities/Properties/Rollup.php
@@ -37,7 +37,7 @@ class Rollup extends Property
                     break;
                 default:
                     throw new HandlingException("Unexpected rollupType {$this->rollupType}");
-        }
+            }
         }
     }
 
@@ -89,10 +89,19 @@ class Rollup extends Property
             // TODO
             $rollupPropertyItem['id'] = 'undefined';
 
-            $this->content->add(
-                Property::fromResponse('', $rollupPropertyItem)
-            );
+            if ($this->isRollupPropertyContentSet($rollupPropertyItem)) {
+                $this->content->add(
+                    Property::fromResponse('', $rollupPropertyItem)
+                );
+            }
         }
+    }
+
+    private function isRollupPropertyContentSet($rollupPropertyItem): bool
+    {
+        return Arr::exists($rollupPropertyItem, 'type')
+            && Arr::exists($rollupPropertyItem, $rollupPropertyItem['type'])
+            && !is_null($rollupPropertyItem[$rollupPropertyItem['type']]);
     }
 
     private function setRollupContentDate()

--- a/tests/EndpointDatabaseTest.php
+++ b/tests/EndpointDatabaseTest.php
@@ -158,7 +158,7 @@ class EndpointDatabaseTest extends NotionApiTest
         Notion::database('8284f3ff77e24d4a939d19459e4d6bdc')->query();
     }
 
-    ## EDGE CASES
+    //# EDGE CASES
 
     /** @test */
     public function it_queries_a_database_with_a_rollup_property_with_empty_selects()
@@ -166,7 +166,7 @@ class EndpointDatabaseTest extends NotionApiTest
         // success /v1/databases/DATABASE_DOES_EXIST/query
         Http::fake([
             'https://api.notion.com/v1/databases/11971214ce574df7a58389c1deda61d7/query*' => Http::response(
-                json_decode(file_get_contents("tests/stubs/endpoints/databases/response_query_rollup_empty_select_200.json"), true),
+                json_decode(file_get_contents('tests/stubs/endpoints/databases/response_query_rollup_empty_select_200.json'), true),
                 200,
                 ['Headers']
             ),

--- a/tests/EndpointDatabaseTest.php
+++ b/tests/EndpointDatabaseTest.php
@@ -158,10 +158,10 @@ class EndpointDatabaseTest extends NotionApiTest
         Notion::database('8284f3ff77e24d4a939d19459e4d6bdc')->query();
     }
 
-    /** 
-     * @test 
+    /**
+     * @test
      * ! edge-case
-    */
+     */
     public function it_queries_a_database_with_a_rollup_property_with_empty_selects()
     {
         // success /v1/databases/DATABASE_DOES_EXIST/query

--- a/tests/EndpointDatabaseTest.php
+++ b/tests/EndpointDatabaseTest.php
@@ -157,4 +157,32 @@ class EndpointDatabaseTest extends NotionApiTest
 
         Notion::database('8284f3ff77e24d4a939d19459e4d6bdc')->query();
     }
+
+    ## EDGE CASES
+
+    /** @test */
+    public function it_queries_a_database_with_a_rollup_property_with_empty_selects()
+    {
+        // success /v1/databases/DATABASE_DOES_EXIST/query
+        Http::fake([
+            'https://api.notion.com/v1/databases/11971214ce574df7a58389c1deda61d7/query*' => Http::response(
+                json_decode(file_get_contents("tests/stubs/endpoints/databases/response_query_rollup_empty_select_200.json"), true),
+                200,
+                ['Headers']
+            ),
+        ]);
+
+        $result = Notion::database('11971214ce574df7a58389c1deda61d7')->query();
+
+        $this->assertInstanceOf(PageCollection::class, $result);
+
+        $resultCollection = $result->asCollection();
+
+        $this->assertIsIterable($resultCollection);
+        $this->assertContainsOnly(Page::class, $resultCollection);
+
+        // check page object
+        $page = $resultCollection->first();
+        $this->assertEquals(0, $page->getProperty('Rollup')->getContent()->count());
+    }
 }

--- a/tests/EndpointDatabaseTest.php
+++ b/tests/EndpointDatabaseTest.php
@@ -158,9 +158,10 @@ class EndpointDatabaseTest extends NotionApiTest
         Notion::database('8284f3ff77e24d4a939d19459e4d6bdc')->query();
     }
 
-    //# EDGE CASES
-
-    /** @test */
+    /** 
+     * @test 
+     * ! edge-case
+    */
     public function it_queries_a_database_with_a_rollup_property_with_empty_selects()
     {
         // success /v1/databases/DATABASE_DOES_EXIST/query

--- a/tests/stubs/endpoints/databases/response_query_rollup_empty_select_200.json
+++ b/tests/stubs/endpoints/databases/response_query_rollup_empty_select_200.json
@@ -1,0 +1,148 @@
+{
+    "object": "list",
+    "results": [
+        {
+            "object": "page",
+            "id": "1321e6b6-0771-48bb-9814-6501c2ec3c32",
+            "created_time": "2022-07-09T10:29:00.000Z",
+            "last_edited_time": "2022-07-09T10:45:00.000Z",
+            "created_by": {
+                "object": "user",
+                "id": "04536682-601a-4531-a18f-4fa89fdf14a8"
+            },
+            "last_edited_by": {
+                "object": "user",
+                "id": "04531682-603a-4531-a18f-1fa89fdfb4a8"
+            },
+            "cover": null,
+            "icon": null,
+            "parent": {
+                "type": "database_id",
+                "database_id": "15971224-ce57-4df1-a583-89c1deca63d7"
+            },
+            "archived": false,
+            "properties": {
+                "Test Rollup Problem": {
+                    "id": "G|zT",
+                    "type": "relation",
+                    "relation": [
+                        {
+                            "id": "dcad104b-222c-4d63-b83e-852f22612f4a"
+                        },
+                        {
+                            "id": "3611ce31-ae52-45dc-bc5a-10626ca19ab5"
+                        }
+                    ]
+                },
+                "Rollup": {
+                    "id": "JCh`",
+                    "type": "rollup",
+                    "rollup": {
+                        "type": "array",
+                        "array": [
+                            {
+                                "type": "select",
+                                "select": null
+                            }
+                        ],
+                        "function": "show_original"
+                    }
+                },
+                "Name": {
+                    "id": "title",
+                    "type": "title",
+                    "title": []
+                }
+            },
+            "url": "https:\/\/www.notion.so\/132de616077648bb98146501c2ec3c32"
+        },
+        {
+            "object": "page",
+            "id": "43dd6b90-6bde-48ea-9f06-79fee96de99c",
+            "created_time": "2022-07-09T10:29:00.000Z",
+            "last_edited_time": "2022-07-09T10:29:00.000Z",
+            "created_by": {
+                "object": "user",
+                "id": "04d36682-603a-4531-a18f-4fa19fdfb4a8"
+            },
+            "last_edited_by": {
+                "object": "user",
+                "id": "04d36682-603a-4531-a18f-4fa891dfb4a8"
+            },
+            "cover": null,
+            "icon": null,
+            "parent": {
+                "type": "database_id",
+                "database_id": "1d9712d4-ce57-4df7-a583-89c1dedac3d7"
+            },
+            "archived": false,
+            "properties": {
+                "Test Rollup Problem": {
+                    "id": "G|zT",
+                    "type": "relation",
+                    "relation": []
+                },
+                "Rollup": {
+                    "id": "JCh`",
+                    "type": "rollup",
+                    "rollup": {
+                        "type": "array",
+                        "array": [],
+                        "function": "show_original"
+                    }
+                },
+                "Name": {
+                    "id": "title",
+                    "type": "title",
+                    "title": []
+                }
+            },
+            "url": "https:\/\/www.notion.so\/430d6b9d6b9e48ea9f067cfee96de9d9"
+        },
+        {
+            "object": "page",
+            "id": "788c67fe-84d2-4cf8-aab6-6cd6448d98b2",
+            "created_time": "2022-07-09T10:29:00.000Z",
+            "last_edited_time": "2022-07-09T10:29:00.000Z",
+            "created_by": {
+                "object": "user",
+                "id": "04536682-613a-4531-a18f-4fd89fdfb4a8"
+            },
+            "last_edited_by": {
+                "object": "user",
+                "id": "04436622-603a-4531-a18f-4fa89fdfb4a8"
+            },
+            "cover": null,
+            "icon": null,
+            "parent": {
+                "type": "database_id",
+                "database_id": "15972224-ce57-4df7-a583-89c1de1a63dd"
+            },
+            "archived": false,
+            "properties": {
+                "Test Rollup Problem": {
+                    "id": "G|zT",
+                    "type": "relation",
+                    "relation": []
+                },
+                "Rollup": {
+                    "id": "JCh`",
+                    "type": "rollup",
+                    "rollup": {
+                        "type": "array",
+                        "array": [],
+                        "function": "show_original"
+                    }
+                },
+                "Name": {
+                    "id": "title",
+                    "type": "title",
+                    "title": []
+                }
+            },
+            "url": "https:\/\/www.notion.so\/788c67de84d24cf8dab660d64c8998b2"
+        }
+    ],
+    "next_cursor": null,
+    "has_more": false
+}


### PR DESCRIPTION
[fix: check if content is set for rollup properties](https://github.com/5am-code/laravel-notion-api/commit/2bfcee476544ea594ef84040e72135bb0c91d8a3) 

- specific rollup properties can be null, which lead to issues of setting the content of the property
- this fix checks the existence of content and skips setting the content, if it is null (e.g. empty selects, multi_selects etc.)
- fixes issue: Rollup that refers to an empty Select property throws exception during database query