### PR TITLE
polish/fix: control over 'includeTime' of Date

### DIFF
--- a/src/Entities/Page.php
+++ b/src/Entities/Page.php
@@ -346,6 +346,19 @@ class Page extends Entity
 
     /**
      * @param $propertyTitle
+     * @param $start
+     * @param $end
+     * @return Page
+     */
+    public function setDateTime(string $propertyTitle, DateTime $start, ?DateTime $end = null): Page
+    {
+        $this->set($propertyTitle, Date::valueWithTime($start, $end));
+
+        return $this;
+    }
+
+    /**
+     * @param $propertyTitle
      * @param $relationIds
      * @return Page
      */

--- a/src/Entities/Properties/Date.php
+++ b/src/Entities/Properties/Date.php
@@ -29,6 +29,39 @@ class Date extends Property implements Modifiable
         if ($richDate->isRange()) {
             $dateProperty->rawContent = [
                 'date' => [
+                    'start' => $start->format('Y-m-d'),
+                    'end' => $end->format('Y-m-d'),
+                ],
+            ];
+        } else {
+            $dateProperty->rawContent = [
+                'date' => [
+                    'start' => $start->format('Y-m-d'),
+                ],
+            ];
+        }
+
+        return $dateProperty;
+    }
+
+    /**
+     * @param $start
+     * @param $end
+     * @return Date
+     */
+    public static function valueWithTime(?DateTime $start, ?DateTime $end = null): Date
+    {
+        $richDate = new RichDate();
+        $richDate->setStart($start);
+        $richDate->setEnd($end);
+        $richDate->setHasTime(true);
+
+        $dateProperty = new Date();
+        $dateProperty->content = $richDate;
+
+        if ($richDate->isRange()) {
+            $dateProperty->rawContent = [
+                'date' => [
                     'start' => $start->format('c'),
                     'end' => $end->format('c'),
                 ],

--- a/src/Entities/Properties/Date.php
+++ b/src/Entities/Properties/Date.php
@@ -6,6 +6,7 @@ use DateTime;
 use FiveamCode\LaravelNotionApi\Entities\Contracts\Modifiable;
 use FiveamCode\LaravelNotionApi\Entities\PropertyItems\RichDate;
 use FiveamCode\LaravelNotionApi\Exceptions\HandlingException;
+use Illuminate\Support\Arr;
 
 /**
  * Class Date.
@@ -90,17 +91,24 @@ class Date extends Property implements Modifiable
     {
         $richDate = new RichDate();
 
-        if (isset($this->rawContent['start'])) {
+        if (Arr::exists($this->rawContent, 'start')) {
             $startAsIsoString = $this->rawContent['start'];
             $richDate->setStart(new DateTime($startAsIsoString));
+            $richDate->setHasTime($this->isIsoTimeString($startAsIsoString));
         }
 
-        if (isset($this->rawContent['end'])) {
+        if (Arr::exists($this->rawContent, 'end')) {
             $endAsIsoString = $this->rawContent['end'];
             $richDate->setEnd(new DateTime($endAsIsoString));
         }
 
         $this->content = $richDate;
+    }
+
+    // function for checking if ISO datetime string includes time or not
+    private function isIsoTimeString(string $isoTimeDateString): bool
+    {
+        return strpos($isoTimeDateString, 'T') !== false;
     }
 
     /**
@@ -128,10 +136,18 @@ class Date extends Property implements Modifiable
     }
 
     /**
-     * @return DateTime
+     * @return ?DateTime
      */
-    public function getEnd(): DateTime
+    public function getEnd(): ?DateTime
     {
         return $this->getContent()->getEnd();
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasTime(): bool
+    {
+        return $this->getContent()->hasTime();
     }
 }

--- a/src/Entities/PropertyItems/RichDate.php
+++ b/src/Entities/PropertyItems/RichDate.php
@@ -11,11 +11,9 @@ use Illuminate\Support\Arr;
  */
 class RichDate extends Entity
 {
-    /**
-     * @var string
-     */
     protected DateTime $start;
     protected ?DateTime $end = null;
+    protected bool $hasTime = false;
 
     /**
      * @param  array  $responseData
@@ -70,6 +68,14 @@ class RichDate extends Entity
         return $this->end;
     }
 
+    /**
+     * @return bool
+     */
+    public function getHasTime(): bool
+    {
+        return $this->hasTime;
+    }
+
     public function setStart($start): void
     {
         $this->start = $start;
@@ -78,5 +84,10 @@ class RichDate extends Entity
     public function setEnd($end): void
     {
         $this->end = $end;
+    }
+
+    public function setHasTime($hasTime): void
+    {
+        $this->hasTime = $hasTime;
     }
 }

--- a/src/Entities/PropertyItems/RichDate.php
+++ b/src/Entities/PropertyItems/RichDate.php
@@ -61,7 +61,7 @@ class RichDate extends Entity
     }
 
     /**
-     * @return DateTime
+     * @return ?DateTime
      */
     public function getEnd(): ?DateTime
     {
@@ -71,7 +71,7 @@ class RichDate extends Entity
     /**
      * @return bool
      */
-    public function getHasTime(): bool
+    public function hasTime(): bool
     {
         return $this->hasTime;
     }

--- a/tests/EndpointPagesTest.php
+++ b/tests/EndpointPagesTest.php
@@ -190,7 +190,6 @@ class EndpointPagesTest extends NotionApiTest
         $this->assertArrayHasKey('end', $dateRangeContent['date']);
         $this->assertEquals($dateRangeEndValue->format('Y-m-d'), $dateRangeContent['date']['end']);
 
-
         // date range (with time)
         $this->assertTrue(
             $this->assertContainsInstanceOf(Date::class, $properties)

--- a/tests/EndpointPagesTest.php
+++ b/tests/EndpointPagesTest.php
@@ -69,9 +69,13 @@ class EndpointPagesTest extends NotionApiTest
         // check properties
         $this->assertSame('Notion Is Awesome', $pageResult->getTitle());
         $this->assertSame('page', $pageResult->getObjectType());
-        $this->assertCount(7, $pageResult->getRawProperties());
-        $this->assertCount(7, $pageResult->getProperties());
-        $this->assertCount(7, $pageResult->getPropertyKeys());
+        $this->assertCount(9, $pageResult->getRawProperties());
+        $this->assertCount(9, $pageResult->getProperties());
+        $this->assertCount(9, $pageResult->getPropertyKeys());
+
+        // check date and datetime properties
+        $this->assertTrue($pageResult->getProperty('DateWithTime')->hasTime());
+        $this->assertFalse($pageResult->getProperty('DateWithoutTime')->hasTime());
 
         $this->assertInstanceOf(Carbon::class, $pageResult->getCreatedTime());
         $this->assertInstanceOf(Carbon::class, $pageResult->getLastEditedTime());
@@ -179,6 +183,7 @@ class EndpointPagesTest extends NotionApiTest
         $this->assertTrue($dateRangeProp->isRange());
         $this->assertEquals($dateRangeStartValue, $dateRangeProp->getStart());
         $this->assertEquals($dateRangeEndValue, $dateRangeProp->getEnd());
+        $this->assertFalse($dateRangeProp->hasTime());
         $this->assertJson($dateRangeProp->asText());
         $this->assertStringContainsString($dateRangeStartValue->format('Y-m-d H:i:s'), $dateRangeProp->asText());
         $this->assertStringContainsString($dateRangeEndValue->format('Y-m-d H:i:s'), $dateRangeProp->asText());
@@ -200,6 +205,7 @@ class EndpointPagesTest extends NotionApiTest
         $this->assertTrue($dateTimeRangeProp->isRange());
         $this->assertEquals($dateRangeStartValue, $dateTimeRangeProp->getStart());
         $this->assertEquals($dateRangeEndValue, $dateTimeRangeProp->getEnd());
+        $this->assertTrue($dateTimeRangeProp->hasTime());
         $this->assertJson($dateTimeRangeProp->asText());
         $this->assertStringContainsString($dateRangeStartValue->format('Y-m-d H:i:s'), $dateTimeRangeProp->asText());
         $this->assertStringContainsString($dateRangeEndValue->format('Y-m-d H:i:s'), $dateTimeRangeProp->asText());
@@ -216,6 +222,8 @@ class EndpointPagesTest extends NotionApiTest
         $this->assertInstanceOf(RichDate::class, $dateProp->getContent());
         $this->assertFalse($dateProp->isRange());
         $this->assertEquals($dateValue, $dateProp->getStart());
+        $this->assertNull($dateProp->getEnd());
+        $this->assertFalse($dateProp->hasTime());
         $dateContent = $dateProp->getRawContent();
         $this->assertArrayHasKey('date', $dateContent);
         $this->assertCount(1, $dateContent['date']);
@@ -227,6 +235,8 @@ class EndpointPagesTest extends NotionApiTest
         $this->assertInstanceOf(RichDate::class, $dateTimeProp->getContent());
         $this->assertFalse($dateTimeProp->isRange());
         $this->assertEquals($dateValue, $dateTimeProp->getStart());
+        $this->assertNull($dateTimeProp->getEnd());
+        $this->assertTrue($dateTimeProp->hasTime());
         $dateTimeContent = $dateTimeProp->getRawContent();
         $this->assertArrayHasKey('date', $dateTimeContent);
         $this->assertCount(1, $dateTimeContent['date']);

--- a/tests/EndpointPagesTest.php
+++ b/tests/EndpointPagesTest.php
@@ -182,9 +182,9 @@ class EndpointPagesTest extends NotionApiTest
         $this->assertArrayHasKey('date', $dateRangeContent);
         $this->assertCount(2, $dateRangeContent['date']);
         $this->assertArrayHasKey('start', $dateRangeContent['date']);
-        $this->assertEquals($dateRangeStartValue->format('c'), $dateRangeContent['date']['start']);
+        $this->assertEquals($dateRangeStartValue->format('Y-m-d'), $dateRangeContent['date']['start']);
         $this->assertArrayHasKey('end', $dateRangeContent['date']);
-        $this->assertEquals($dateRangeEndValue->format('c'), $dateRangeContent['date']['end']);
+        $this->assertEquals($dateRangeEndValue->format('Y-m-d'), $dateRangeContent['date']['end']);
 
         // date
         $dateProp = $page->getProperty($dateKey);
@@ -195,7 +195,7 @@ class EndpointPagesTest extends NotionApiTest
         $this->assertArrayHasKey('date', $dateContent);
         $this->assertCount(1, $dateContent['date']);
         $this->assertArrayHasKey('start', $dateContent['date']);
-        $this->assertEquals($dateValue->format('c'), $dateContent['date']['start']);
+        $this->assertEquals($dateValue->format('Y-m-d'), $dateContent['date']['start']);
 
         // email
         $this->assertTrue($this->assertContainsInstanceOf(Email::class, $properties));

--- a/tests/stubs/endpoints/pages/response_specific_200.json
+++ b/tests/stubs/endpoints/pages/response_specific_200.json
@@ -40,6 +40,24 @@
                 }
             ]
         },
+        "DateWithTime":{
+            "id": ">d{D",
+            "type": "date",
+            "date": {
+                "start": "2021-05-14T00:00:00.000+00:00",
+                "end": "2021-06-14T00:00:00.000+00:00",
+                "time_zone": null
+            }
+        },
+        "DateWithoutTime":{
+            "id": ">c{d",
+            "type": "date",
+            "date": {
+                "start": "2021-05-14",
+                "end": "2021-06-14",
+                "time_zone": null
+            }
+        },
         "SelectColumn": {
             "id": "nKff",
             "type": "select",


### PR DESCRIPTION
- introduce new methods for actively including time ('include Time') of a Date Properties within a Notion Page
- existing init of value for a Date Property will force a date without time
- ::valueWithTime(...) in Date Property and ->setDateTime(...) in Page will force the inclusion of time, if pushed to Notion
- ! breaking: result of ::value(...) of Date Property and ->setDate(...) of Page are changing (time will not be included)