### PR TITLE
NotionException: Use status from http response

### DIFF
--- a/src/Exceptions/NotionException.php
+++ b/src/Exceptions/NotionException.php
@@ -46,7 +46,7 @@ class NotionException extends LaravelNotionAPIException
 
         return new NotionException(
             $message,
-            0,
+            $response->status(),
             $response->toException()
         );
     }


### PR DESCRIPTION
In a try-catch it is useful to get the http status code. For example, to check if too many requests were made (Status 429).