### PR TITLE
Do not serialize scalar values

### DIFF
--- a/src/Entities/Properties/Property.php
+++ b/src/Entities/Properties/Property.php
@@ -115,6 +115,10 @@ class Property extends Entity
             return '';
         }
 
+        if (is_scalar($this->content)) {
+            return $this->content;
+        }
+
         return json_encode($this->content);
     }
 


### PR DESCRIPTION
I don't know why all properties are becoming json_encoded, but this resulted in properties having malicious characters (i.e., `"`) when using `asText()`.

## Example: 
**Before:**
```php
$page->getProperty('E-Mail-Adresse')->asText(); // "me@example.org"
```
**After:**
```php
$page->getProperty('E-Mail-Adresse')->asText(); // me@example.org
```