### PR TITLE
Add Select::id()

### DIFF
--- a/src/Entities/Properties/Select.php
+++ b/src/Entities/Properties/Select.php
@@ -17,6 +17,28 @@ class Select extends Property implements Modifiable
      */
     private Collection $options;
 
+    
+    /**
+     * @param $id
+     * @return Select
+     */
+    public static function id(string $id): Select
+    {
+        $selectProperty = new Select();
+
+        $selectItem = new SelectItem();
+        $selectItem->setId($id);
+        $selectProperty->content = $selectItem;
+
+        $selectProperty->rawContent = [
+            'select' => [
+                'id' => $selectItem->getId(),
+            ],
+        ];
+
+        return $selectProperty;
+    }
+
     /**
      * @param $name
      * @return Select


### PR DESCRIPTION
Shorthand method for when you want to reference a select by its id rather than textual representation.