### PR TITLE
fix null error during creation of NotionException

### DIFF
--- a/src/Exceptions/NotionException.php
+++ b/src/Exceptions/NotionException.php
@@ -3,6 +3,7 @@
 namespace FiveamCode\LaravelNotionApi\Exceptions;
 
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
 
 /**
  * Class NotionException.
@@ -44,11 +45,11 @@ class NotionException extends LaravelNotionAPIException
         $responseBody = json_decode($response->getBody()->getContents(), true);
 
         $errorCode = $errorMessage = '';
-        if (array_key_exists('code', $responseBody)) {
+        if (Arr::exists($responseBody ?? [], 'code')) {
             $errorCode = "({$responseBody['code']})";
         }
 
-        if (array_key_exists('code', $responseBody)) {
+        if (Arr::exists($responseBody ?? [], 'code')) {
             $errorMessage = "({$responseBody['message']})";
         }
 


### PR DESCRIPTION
- replace `array_key_exists` with `Arr::exists(...)`
- if `$responseBody` == null, insert empty array